### PR TITLE
Update logo index to logo_details

### DIFF
--- a/templates/_partials/header.tpl
+++ b/templates/_partials/header.tpl
@@ -63,12 +63,12 @@
       {if $page.page_name == 'index'}
         <a class="navbar-brand" href="{$urls.pages.index}">
           <h1>
-              <img class="logo img-responsive" src="{$shop.logo}" alt="{$shop.name}" loading="lazy" width="100" height="28">
+              <img class="logo img-responsive" src="{$shop.logo_details.src}" alt="{$shop.name}" loading="lazy" width="{$shop.logo_details.width}" height="{$shop.logo_details.height}">
           </h1>
         </a>
       {else}
         <a class="navbar-brand" href="{$urls.pages.index}">
-          <img class="logo img-responsive" src="{$shop.logo}" alt="{$shop.name}" loading="lazy" width="100" height="28">
+          <img class="logo img-responsive" src="{$shop.logo_details.src}" alt="{$shop.name}" loading="lazy" width="{$shop.logo_details.width}" height="{$shop.logo_details.height}">
         </a>
       {/if}
 

--- a/templates/_partials/microdata/head-jsonld.tpl
+++ b/templates/_partials/microdata/head-jsonld.tpl
@@ -30,7 +30,7 @@
     "url" : "{$urls.pages.index}",
     "logo": {
       "@type": "ImageObject",
-      "url":"{$shop.logo}"
+      "url":"{$shop.logo_details.src}"
     }
   }
 </script>
@@ -57,7 +57,7 @@
       "url" : "{$urls.pages.index}",
       "image": {
         "@type": "ImageObject",
-        "url":"{$shop.logo}"
+        "url":"{$shop.logo_details.src}"
       },
       "potentialAction": {
         "@type": "SearchAction",

--- a/templates/checkout/_partials/header.tpl
+++ b/templates/checkout/_partials/header.tpl
@@ -28,7 +28,7 @@
       <div class="row">
         <div class="col-md-6 d-none d-sm-block d-md-block" id="_desktop_logo">
           <a href="{$urls.pages.index}">
-            <img class="logo img-responsive" src="{$shop.logo}" alt="{$shop.name} {l s='logo' d='Shop.Theme.Global'}" loading="lazy">
+            <img class="logo img-responsive" src="{$shop.logo_details.src}" alt="{$shop.name} {l s='logo' d='Shop.Theme.Global'}" loading="lazy">
           </a>
         </div>
         <div class="col-md-6 text-xs-right d-none d-sm-block d-md-block">

--- a/templates/errors/maintenance.tpl
+++ b/templates/errors/maintenance.tpl
@@ -31,7 +31,7 @@
     {block name='page_header_container'}
       <header class="page-header">
         {block name='page_header_logo'}
-        <div class="logo"><img src="{$shop.logo}" alt="logo" loading="lazy"></div>
+        <div class="logo"><img src="{$shop.logo_details.src}" alt="logo" loading="lazy"></div>
         {/block}
 
         {block name='hook_maintenance'}

--- a/templates/errors/restricted-country.tpl
+++ b/templates/errors/restricted-country.tpl
@@ -30,7 +30,7 @@
 
     {block name='page_header_container'}
       <header class="page-header">
-        <div class="logo"><img src="{$shop.logo}" alt="logo" loading="lazy"></div>
+        <div class="logo"><img src="{$shop.logo_details.src}" alt="logo" loading="lazy"></div>
         {block name='page_header'}
           <h1>{block name='page_title'}{$shop.name}{/block}</h1>
         {/block}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Regarding PR #26225 on PrestaShop project, logo is now logo_details to avoid BC break.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Wait the merge of this PR, be on develop branch and see that logo is no more an array.
| Possible impacts? | Nothing.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
