### PR TITLE
Fix active link for blockwishlist

### DIFF
--- a/modules/blockwishlist/views/templates/hook/displayCustomerAccount.tpl
+++ b/modules/blockwishlist/views/templates/hook/displayCustomerAccount.tpl
@@ -17,7 +17,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-<a class="col-md-6 col-lg-4" id="wishlist-link" href="{$url}">
+<a class="col-md-6 col-lg-4{if $urls.current_url === $url} active{/if}" id="wishlist-link" href="{$url}">
   <span class="link-item">
     <i class="material-icons">favorite</i>
     {$wishlistsTitlePage}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When blockwishlist is selected from account menu, the corresponding link should be in active state.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | -
| Possible impacts? | My Account page.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

![Screenshot 2022-01-20 at 12-56-56 Wishlist](https://user-images.githubusercontent.com/85633460/150344026-6d2cdce7-2ec5-4e14-8702-bfb471e9bb33.png)

