### PR TITLE
Using Vazir font for shops in RTL language

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "material-design-icons-iconfont": "^5.0.1",
     "nouislider": "^15.5.0",
     "swiper": "^7.4.1",
+    "vazir-font": "^30.1.0",
     "wnumb": "^1.2.0"
   }
 }

--- a/src/scss/rtl.scss
+++ b/src/scss/rtl.scss
@@ -1,5 +1,11 @@
 // Custom CSS rules for RTL should be included here.
 // This file will be used automatically if shop language is RTL.
+@import "~vazir-font/dist/font-face.css";
+
+body {
+  font-family: Vazir,sans-serif;
+}
+
 .material-icons {
   &.rtl-flip {
     transform: scaleX(-1);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | [Vazir](https://github.com/rastikerdar/vazir-font) is a Persian/Arabic font.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | -
| Possible impacts? | Font face in RTL version of theme-refacto.
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

![Screenshot 2022-01-21 at 11-52-07 Hummingbird printed t-shirt](https://user-images.githubusercontent.com/85633460/150523810-d0a368fd-214e-4360-a3aa-19aed9e4d83c.png)

![Screenshot from 2022-01-21 11-54-51](https://user-images.githubusercontent.com/85633460/150523817-7ddde2c0-e10d-4624-a8e8-342b0316dff0.png)

