### PR TITLE
Fix products sort order dropdown in Search page

### DIFF
--- a/src/scss/custom/components/category/_product-list.scss
+++ b/src/scss/custom/components/category/_product-list.scss
@@ -2,7 +2,10 @@
   #left-column {
     padding-right: 3rem;
   }
+}
 
+.layout-left-column,
+.layout-full-width {
   .products-selection {
     margin-bottom: 1.25rem;
 

--- a/templates/catalog/listing/search.tpl
+++ b/templates/catalog/listing/search.tpl
@@ -4,6 +4,10 @@
  *}
 {extends file='catalog/listing/product-list.tpl'}
 
+{block name='product_list'}
+  {include file='catalog/_partials/products.tpl' listing=$listing productClass="col-6 col-md-4 col-xl-3"}
+{/block}
+
 {block name="error_content"}
   <h4>{l s='No matches were found for your search' d='Shop.Theme.Catalog'}</h4>
   <p>{l s='Please try other keywords to describe what you are looking for.' d='Shop.Theme.Catalog'}</p>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix products sort order dropdown in Search page, and increase number of products per row (we don't have left-column in Search page).
| Type?             | bug fix / improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | -
| Possible impacts? | Search page UI.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

![Screenshot 2022-01-21 at 13-53-54 Search](https://user-images.githubusercontent.com/85633460/150540020-232ec2b9-3c06-4855-8396-404711867399.png)
