### PR TITLE
Redesign color group UI in faceted search

### DIFF
--- a/modules/ps_facetedsearch/views/templates/front/catalog/facets.tpl
+++ b/modules/ps_facetedsearch/views/templates/front/catalog/facets.tpl
@@ -58,12 +58,12 @@
                       {continue}
                     {/if}
 
-                    <li>
+                    <li {if isset($filter.properties.color) || isset($filter.properties.texture)}class="d-inline-block"{/if}>
                       <div class="{$componentName}-label facet-label{if $filter.active} active {/if}">
                         {if $facet.multipleSelectionAllowed}
-                          <div class="form-check">
+                          <div class="form-check{if isset($filter.properties.color) || isset($filter.properties.texture)} px-0{/if}">
                             <input 
-                              class="form-check-input" 
+                              class="form-check-input{if isset($filter.properties.color) || isset($filter.properties.texture)} visually-hidden{/if}" 
                               id="facet_input_{$_expand_id}_{$filter_key}"
                               data-search-url="{$filter.nextEncodedFacetsURL}"
                               type="checkbox"


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Change the color group UI to inline-block display and hide input checkbox.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | -
| How to test?      | -
| Possible impacts? | Color selection group in faceted search.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->


| Current  | PR |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/85633460/150650049-68d82274-6690-489b-8dfd-b25eda0d716b.png" width="250">  | <img src="https://user-images.githubusercontent.com/85633460/150649935-45af6d69-5dee-4201-b71e-9ae1a7a7848d.png" width="250"> | 




