### PR TITLE
Styling of confirmation page and default module messages

### DIFF
--- a/modules/ps_cashondelivery/index.php
+++ b/modules/ps_cashondelivery/index.php
@@ -1,0 +1,35 @@
+<?php
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+                        
+header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
+header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
+                        
+header("Cache-Control: no-store, no-cache, must-revalidate");
+header("Cache-Control: post-check=0, pre-check=0", false);
+header("Pragma: no-cache");
+                        
+header("Location: ../");
+exit;

--- a/modules/ps_cashondelivery/views/index.php
+++ b/modules/ps_cashondelivery/views/index.php
@@ -1,0 +1,35 @@
+<?php
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+                        
+header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
+header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
+                        
+header("Cache-Control: no-store, no-cache, must-revalidate");
+header("Cache-Control: post-check=0, pre-check=0", false);
+header("Pragma: no-cache");
+                        
+header("Location: ../");
+exit;

--- a/modules/ps_cashondelivery/views/templates/hook/index.php
+++ b/modules/ps_cashondelivery/views/templates/hook/index.php
@@ -1,0 +1,35 @@
+<?php
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+                        
+header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
+header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
+                        
+header("Cache-Control: no-store, no-cache, must-revalidate");
+header("Cache-Control: post-check=0, pre-check=0", false);
+header("Pragma: no-cache");
+                        
+header("Location: ../");
+exit;

--- a/modules/ps_cashondelivery/views/templates/hook/payment_return.tpl
+++ b/modules/ps_cashondelivery/views/templates/hook/payment_return.tpl
@@ -1,0 +1,32 @@
+{*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+<p>
+  {l s='Your order on %s is complete.' sprintf=[$shop_name] d='Modules.Cashondelivery.Shop'}
+  <br><br>
+  {l s='You have chosen the cash on delivery method.' d='Modules.Cashondelivery.Shop'}
+  <br><br><span>{l s='Your order will be sent very soon.' d='Modules.Cashondelivery.Shop'}</span>
+  <br><br>{l s='For any questions or for further information, please contact our' d='Modules.Cashondelivery.Shop'} <a href="{$contact_url}">{l s='customer support' d='Modules.Cashondelivery.Shop'}</a>.
+</p>

--- a/modules/ps_cashondelivery/views/templates/hook/payment_return.tpl
+++ b/modules/ps_cashondelivery/views/templates/hook/payment_return.tpl
@@ -23,10 +23,16 @@
 *  International Registered Trademark & Property of PrestaShop SA
 *}
 
-<p>
-  {l s='Your order on %s is complete.' sprintf=[$shop_name] d='Modules.Cashondelivery.Shop'}
-  <br><br>
-  {l s='You have chosen the cash on delivery method.' d='Modules.Cashondelivery.Shop'}
-  <br><br><span>{l s='Your order will be sent very soon.' d='Modules.Cashondelivery.Shop'}</span>
-  <br><br>{l s='For any questions or for further information, please contact our' d='Modules.Cashondelivery.Shop'} <a href="{$contact_url}">{l s='customer support' d='Modules.Cashondelivery.Shop'}</a>.
-</p>
+<div class="card card-body bg-light mb-3 order-confirmation__payment">
+  <h2 class="h4">{l s='Payment information' d='Shop.Theme.Checkout'}</h2>
+
+  <p>
+    {l s='You have chosen the cash on delivery method.' d='Modules.Cashondelivery.Shop'}
+    {l s='Your order will be sent very soon.' d='Modules.Cashondelivery.Shop'}
+  </p>
+
+  <p class="mb-0">
+    {l s='For any questions or for further information, please contact our' d='Modules.Cashondelivery.Shop'} 
+    <a href="{$contact_url}">{l s='customer support' d='Modules.Cashondelivery.Shop'}</a>.
+  </p>
+</div>

--- a/modules/ps_cashondelivery/views/templates/index.php
+++ b/modules/ps_cashondelivery/views/templates/index.php
@@ -1,0 +1,35 @@
+<?php
+/*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*/
+                        
+header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
+header("Last-Modified: ".gmdate("D, d M Y H:i:s")." GMT");
+                        
+header("Cache-Control: no-store, no-cache, must-revalidate");
+header("Cache-Control: post-check=0, pre-check=0", false);
+header("Pragma: no-cache");
+                        
+header("Location: ../");
+exit;

--- a/modules/ps_checkpayment/index.php
+++ b/modules/ps_checkpayment/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/ps_checkpayment/views/index.php
+++ b/modules/ps_checkpayment/views/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/ps_checkpayment/views/templates/hook/index.php
+++ b/modules/ps_checkpayment/views/templates/hook/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/ps_checkpayment/views/templates/hook/payment_return.tpl
+++ b/modules/ps_checkpayment/views/templates/hook/payment_return.tpl
@@ -1,0 +1,79 @@
+{**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ *}
+
+{if $status == 'ok'}
+	<p>
+		{l s='Your order on %s is complete.' sprintf=[$shop_name] d='Modules.Checkpayment.Shop'}
+	</p>
+
+	<p>
+		{l s='Your check must include:' d='Modules.Checkpayment.Shop'}
+	</p>
+
+	<ul>
+		<li>
+			{l s='Payment amount.' d='Modules.Checkpayment.Shop'}
+			<span class="price"><strong>{$total_to_pay}</strong></span>
+		</li>
+
+		<li>
+			{l s='Payable to the order of' d='Modules.Checkpayment.Shop'}
+			<strong>{if $checkName}{$checkName}{else}___________{/if}</strong>
+		</li>
+
+		<li>
+			{l s='Mail to' d='Modules.Checkpayment.Shop'}
+			<strong>{if $checkAddress}{$checkAddress nofilter}{else}___________{/if}</strong>
+		</li>
+
+		{if !isset($reference)}
+			<li>
+				{l s='Do not forget to insert your order number #%d.' sprintf=[$id_order] d='Modules.Checkpayment.Shop'}
+			</li>
+		{else}
+			<li>
+				{l s='Do not forget to insert your order reference %s.' sprintf=[$reference] d='Modules.Checkpayment.Shop'}
+			</li>
+		{/if}
+	</ul>
+
+	<p>
+		{l s='An email has been sent to you with this information.' d='Modules.Checkpayment.Shop'}
+	</p>
+
+	<p>
+		<strong>{l s='Your order will be sent as soon as we receive your payment.' d='Modules.Checkpayment.Shop'}</strong>
+	</p>
+
+	<p>
+		{l s='For any questions or for further information, please contact our' d='Modules.Checkpayment.Shop'}
+		<a href="{$link->getPageLink('contact', true)|escape:'html'}">{l s='customer service department.' d='Modules.Checkpayment.Shop'}</a>.
+	</p>
+{else}
+	<p class="warning">
+		{l s='We have noticed that there is a problem with your order. If you think this is an error, you can contact our' d='Modules.Checkpayment.Shop'}
+		<a href="{$link->getPageLink('contact', true)|escape:'html'}">{l s='customer service department.' d='Modules.Checkpayment.Shop'}</a>.
+	</p>
+{/if}

--- a/modules/ps_checkpayment/views/templates/hook/payment_return.tpl
+++ b/modules/ps_checkpayment/views/templates/hook/payment_return.tpl
@@ -23,57 +23,41 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 
-{if $status == 'ok'}
-	<p>
-		{l s='Your order on %s is complete.' sprintf=[$shop_name] d='Modules.Checkpayment.Shop'}
-	</p>
+<div class="card card-body bg-light mb-3 order-confirmation__payment">
+<h2 class="h4">{l s='Payment information' d='Shop.Theme.Checkout'}</h2>
+	{if $status == 'ok'}
+		<p>
+			{l s='You have chosen payment by check.' d='Modules.Cashondelivery.Shop'}<br/>
+			{l s='Your check must include following details:' d='Modules.Checkpayment.Shop'}
+		</p>
 
-	<p>
-		{l s='Your check must include:' d='Modules.Checkpayment.Shop'}
-	</p>
+		<dl>
+			<dt>{l s='Payment amount.' d='Modules.Checkpayment.Shop'}</dt>
+			<dd>{$total_to_pay}</dd>
+			<dt>{l s='Payable to the order of' d='Modules.Checkpayment.Shop'}</dt>
+			<dd>{if $checkName}{$checkName}{else}___________{/if}</dd>
+			<dt>{l s='Mail to' d='Modules.Checkpayment.Shop'}</dt>
+			<dd>{if $checkAddress}{$checkAddress nofilter}{else}___________{/if}</dd>
+		</dl>
 
-	<ul>
-		<li>
-			{l s='Payment amount.' d='Modules.Checkpayment.Shop'}
-			<span class="price"><strong>{$total_to_pay}</strong></span>
-		</li>
+		<p>
+			{if !isset($reference)}
+				{l s='Do not forget to insert your order number #%d.' sprintf=[$id_order] d='Modules.Checkpayment.Shop'}<br/>
+			{else}
+				{l s='Do not forget to insert your order reference %s.' sprintf=[$reference] d='Modules.Checkpayment.Shop'}<br/>
+			{/if}
+			{l s='An email has been sent to you with this information.' d='Modules.Checkpayment.Shop'}<br/>
+			{l s='Your order will be sent as soon as we receive your payment.' d='Modules.Checkpayment.Shop'}
+		</p>
 
-		<li>
-			{l s='Payable to the order of' d='Modules.Checkpayment.Shop'}
-			<strong>{if $checkName}{$checkName}{else}___________{/if}</strong>
-		</li>
-
-		<li>
-			{l s='Mail to' d='Modules.Checkpayment.Shop'}
-			<strong>{if $checkAddress}{$checkAddress nofilter}{else}___________{/if}</strong>
-		</li>
-
-		{if !isset($reference)}
-			<li>
-				{l s='Do not forget to insert your order number #%d.' sprintf=[$id_order] d='Modules.Checkpayment.Shop'}
-			</li>
-		{else}
-			<li>
-				{l s='Do not forget to insert your order reference %s.' sprintf=[$reference] d='Modules.Checkpayment.Shop'}
-			</li>
-		{/if}
-	</ul>
-
-	<p>
-		{l s='An email has been sent to you with this information.' d='Modules.Checkpayment.Shop'}
-	</p>
-
-	<p>
-		<strong>{l s='Your order will be sent as soon as we receive your payment.' d='Modules.Checkpayment.Shop'}</strong>
-	</p>
-
-	<p>
-		{l s='For any questions or for further information, please contact our' d='Modules.Checkpayment.Shop'}
-		<a href="{$link->getPageLink('contact', true)|escape:'html'}">{l s='customer service department.' d='Modules.Checkpayment.Shop'}</a>.
-	</p>
-{else}
-	<p class="warning">
-		{l s='We have noticed that there is a problem with your order. If you think this is an error, you can contact our' d='Modules.Checkpayment.Shop'}
-		<a href="{$link->getPageLink('contact', true)|escape:'html'}">{l s='customer service department.' d='Modules.Checkpayment.Shop'}</a>.
-	</p>
-{/if}
+		<p class="mb-0">
+			{l s='For any questions or for further information, please contact our' d='Modules.Checkpayment.Shop'}
+			<a href="{$link->getPageLink('contact', true)|escape:'html'}">{l s='customer service department.' d='Modules.Checkpayment.Shop'}</a>.
+		</p>
+	{else}
+		<p class="warning mb-0">
+			{l s='We have noticed that there is a problem with your order. If you think this is an error, you can contact our' d='Modules.Checkpayment.Shop'}
+			<a href="{$link->getPageLink('contact', true)|escape:'html'}">{l s='customer service department.' d='Modules.Checkpayment.Shop'}</a>.
+		</p>
+	{/if}
+</div>

--- a/modules/ps_checkpayment/views/templates/hook/payment_return.tpl
+++ b/modules/ps_checkpayment/views/templates/hook/payment_return.tpl
@@ -31,14 +31,33 @@
 			{l s='Your check must include following details:' d='Modules.Checkpayment.Shop'}
 		</p>
 
-		<dl>
-			<dt>{l s='Payment amount.' d='Modules.Checkpayment.Shop'}</dt>
-			<dd>{$total_to_pay}</dd>
-			<dt>{l s='Payable to the order of' d='Modules.Checkpayment.Shop'}</dt>
-			<dd>{if $checkName}{$checkName}{else}___________{/if}</dd>
-			<dt>{l s='Mail to' d='Modules.Checkpayment.Shop'}</dt>
-			<dd>{if $checkAddress}{$checkAddress nofilter}{else}___________{/if}</dd>
-		</dl>
+    <div class="row mt-2">
+      <div class="col-md-6 fw-bold">
+				{l s='Payment amount.' d='Modules.Checkpayment.Shop'}
+      </div>
+      <div class="col-md-6">
+				{$total_to_pay}
+      </div>
+    </div>
+    <hr/>
+    <div class="row">
+      <div class="col-md-6 fw-bold">
+				{l s='Payable to the order of' d='Modules.Checkpayment.Shop'}
+      </div>
+      <div class="col-md-6">
+				{if $checkName}{$checkName}{else}___________{/if}
+      </div>
+    </div>
+    <hr/>
+    <div class="row mb-4">
+      <div class="col-md-6 fw-bold">
+				{l s='Mail to' d='Modules.Checkpayment.Shop'}
+      </div>
+      <div class="col-md-6">
+				{if $checkAddress}{$checkAddress nofilter}{else}___________{/if}
+      </div>
+    </div>
+
 
 		<p>
 			{if !isset($reference)}

--- a/modules/ps_checkpayment/views/templates/hook/payment_return.tpl
+++ b/modules/ps_checkpayment/views/templates/hook/payment_return.tpl
@@ -32,7 +32,7 @@
 		</p>
 
     <div class="row mt-2">
-      <div class="col-md-6 fw-bold">
+      <div class="col-md-6 fw-bold mb-2 mb-md-0">
 				{l s='Payment amount.' d='Modules.Checkpayment.Shop'}
       </div>
       <div class="col-md-6">
@@ -41,7 +41,7 @@
     </div>
     <hr/>
     <div class="row">
-      <div class="col-md-6 fw-bold">
+      <div class="col-md-6 fw-bold mb-2 mb-md-0">
 				{l s='Payable to the order of' d='Modules.Checkpayment.Shop'}
       </div>
       <div class="col-md-6">
@@ -50,7 +50,7 @@
     </div>
     <hr/>
     <div class="row mb-4">
-      <div class="col-md-6 fw-bold">
+      <div class="col-md-6 fw-bold mb-2 mb-md-0">
 				{l s='Mail to' d='Modules.Checkpayment.Shop'}
       </div>
       <div class="col-md-6">

--- a/modules/ps_checkpayment/views/templates/hook/payment_return.tpl
+++ b/modules/ps_checkpayment/views/templates/hook/payment_return.tpl
@@ -24,7 +24,7 @@
  *}
 
 <div class="card card-body bg-light mb-3 order-confirmation__payment">
-<h2 class="h4">{l s='Payment information' d='Shop.Theme.Checkout'}</h2>
+  <h2 class="h4">{l s='Payment information' d='Shop.Theme.Checkout'}</h2>
 	{if $status == 'ok'}
 		<p>
 			{l s='You have chosen payment by check.' d='Modules.Cashondelivery.Shop'}<br/>

--- a/modules/ps_checkpayment/views/templates/index.php
+++ b/modules/ps_checkpayment/views/templates/index.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/ps_wirepayment/index.php
+++ b/modules/ps_wirepayment/index.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * 2007-2020 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../');
+exit;

--- a/modules/ps_wirepayment/views/index.php
+++ b/modules/ps_wirepayment/views/index.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * 2007-2020 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../');
+exit;

--- a/modules/ps_wirepayment/views/templates/hook/index.php
+++ b/modules/ps_wirepayment/views/templates/hook/index.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * 2007-2020 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../../../');
+exit;

--- a/modules/ps_wirepayment/views/templates/hook/payment_return.tpl
+++ b/modules/ps_wirepayment/views/templates/hook/payment_return.tpl
@@ -1,0 +1,39 @@
+{**
+ * 2007-2020 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ *}
+
+{if $status == 'ok'}
+    <p>
+      {l s='Your order on %s is complete.' sprintf=[$shop_name] d='Modules.Wirepayment.Shop'}<br/>
+      {l s='Please send us a bank wire with:' d='Modules.Wirepayment.Shop'}
+    </p>
+    {include file='module:ps_wirepayment/views/templates/hook/_partials/payment_infos.tpl'}
+
+    <p>
+      {l s='Please specify your order reference %s in the bankwire description.' sprintf=[$reference] d='Modules.Wirepayment.Shop'}<br/>
+      {l s='We\'ve also sent you this information by e-mail.' d='Modules.Wirepayment.Shop'}
+    </p>
+    <strong>{l s='Your order will be sent as soon as we receive payment.' d='Modules.Wirepayment.Shop'}</strong>
+    <p>
+      {l s='If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].' d='Modules.Wirepayment.Shop' sprintf=['[1]' => "<a href='{$contact_url}'>", '[/1]' => '</a>']}
+    </p>
+{else}
+    <p class="warning">
+      {l s='We noticed a problem with your order. If you think this is an error, feel free to contact our [1]expert customer support team[/1].' d='Modules.Wirepayment.Shop' sprintf=['[1]' => "<a href='{$contact_url}'>", '[/1]' => '</a>']}
+    </p>
+{/if}

--- a/modules/ps_wirepayment/views/templates/hook/payment_return.tpl
+++ b/modules/ps_wirepayment/views/templates/hook/payment_return.tpl
@@ -18,7 +18,7 @@
  *}
 
 <div class="card card-body bg-light mb-3 order-confirmation__payment">
-<h2 class="h4">{l s='Payment information' d='Shop.Theme.Checkout'}</h2>
+  <h2 class="h4">{l s='Payment information' d='Shop.Theme.Checkout'}</h2>
   {if $status == 'ok'}
     <p>
       {l s='You have chosen payment by bank transfer.' d='Modules.Cashondelivery.Shop'}<br/>

--- a/modules/ps_wirepayment/views/templates/hook/payment_return.tpl
+++ b/modules/ps_wirepayment/views/templates/hook/payment_return.tpl
@@ -25,17 +25,42 @@
       {l s='Please send us a bank transfer with following details:' d='Modules.Wirepayment.Shop'}
     </p>
 
-    <dl>
-      <dt>{l s='Amount' d='Modules.Wirepayment.Shop'}</dt>
-      <dd>{$total}</dd>
-      <dt>{l s='Name of account owner' d='Modules.Wirepayment.Shop'}</dt>
-      <dd>{$bankwireOwner}</dd>
-      <dt>{l s='Please include these details' d='Modules.Wirepayment.Shop'}</dt>
-      <dd>{$bankwireDetails nofilter}</dd>
-      <dt>{l s='Bank name' d='Modules.Wirepayment.Shop'}</dt>
-      <dd>{$bankwireAddress nofilter}</dd>
-    </dl>
-    
+    <div class="row mt-2">
+      <div class="col-md-6 fw-bold">
+        {l s='Amount' d='Modules.Wirepayment.Shop'}
+      </div>
+      <div class="col-md-6">
+        {$total}
+      </div>
+    </div>
+    <hr/>
+    <div class="row">
+      <div class="col-md-6 fw-bold">
+        {l s='Name of account owner' d='Modules.Wirepayment.Shop'}
+      </div>
+      <div class="col-md-6">
+        {$bankwireOwner}
+      </div>
+    </div>
+    <hr/>
+    <div class="row">
+      <div class="col-md-6 fw-bold">
+        {l s='Please include these details' d='Modules.Wirepayment.Shop'}
+      </div>
+      <div class="col-md-6">
+        {$bankwireDetails nofilter}
+      </div>
+    </div>
+    <hr/>
+    <div class="row mb-4">
+      <div class="col-md-6 fw-bold">
+        {l s='Bank name' d='Modules.Wirepayment.Shop'}
+      </div>
+      <div class="col-md-6">
+      {$bankwireAddress nofilter}
+      </div>
+    </div>
+
     <p>
       {l s='Please specify your order reference %s in the bankwire description.' sprintf=[$reference] d='Modules.Wirepayment.Shop'}<br/>
       {l s='We\'ve also sent you this information by e-mail.' d='Modules.Wirepayment.Shop'}<br/>

--- a/modules/ps_wirepayment/views/templates/hook/payment_return.tpl
+++ b/modules/ps_wirepayment/views/templates/hook/payment_return.tpl
@@ -26,7 +26,7 @@
     </p>
 
     <div class="row mt-2">
-      <div class="col-md-6 fw-bold">
+      <div class="col-md-6 fw-bold mb-2 mb-md-0">
         {l s='Amount' d='Modules.Wirepayment.Shop'}
       </div>
       <div class="col-md-6">
@@ -35,7 +35,7 @@
     </div>
     <hr/>
     <div class="row">
-      <div class="col-md-6 fw-bold">
+      <div class="col-md-6 fw-bold mb-2 mb-md-0">
         {l s='Name of account owner' d='Modules.Wirepayment.Shop'}
       </div>
       <div class="col-md-6">
@@ -44,7 +44,7 @@
     </div>
     <hr/>
     <div class="row">
-      <div class="col-md-6 fw-bold">
+      <div class="col-md-6 fw-bold mb-2 mb-md-0">
         {l s='Please include these details' d='Modules.Wirepayment.Shop'}
       </div>
       <div class="col-md-6">
@@ -53,7 +53,7 @@
     </div>
     <hr/>
     <div class="row mb-4">
-      <div class="col-md-6 fw-bold">
+      <div class="col-md-6 fw-bold mb-2 mb-md-0">
         {l s='Bank name' d='Modules.Wirepayment.Shop'}
       </div>
       <div class="col-md-6">

--- a/modules/ps_wirepayment/views/templates/hook/payment_return.tpl
+++ b/modules/ps_wirepayment/views/templates/hook/payment_return.tpl
@@ -17,23 +17,38 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 
-{if $status == 'ok'}
+<div class="card card-body bg-light mb-3 order-confirmation__payment">
+<h2 class="h4">{l s='Payment information' d='Shop.Theme.Checkout'}</h2>
+  {if $status == 'ok'}
     <p>
-      {l s='Your order on %s is complete.' sprintf=[$shop_name] d='Modules.Wirepayment.Shop'}<br/>
-      {l s='Please send us a bank wire with:' d='Modules.Wirepayment.Shop'}
+      {l s='You have chosen payment by bank transfer.' d='Modules.Cashondelivery.Shop'}<br/>
+      {l s='Please send us a bank transfer with following details:' d='Modules.Wirepayment.Shop'}
     </p>
-    {include file='module:ps_wirepayment/views/templates/hook/_partials/payment_infos.tpl'}
 
+    <dl>
+      <dt>{l s='Amount' d='Modules.Wirepayment.Shop'}</dt>
+      <dd>{$total}</dd>
+      <dt>{l s='Name of account owner' d='Modules.Wirepayment.Shop'}</dt>
+      <dd>{$bankwireOwner}</dd>
+      <dt>{l s='Please include these details' d='Modules.Wirepayment.Shop'}</dt>
+      <dd>{$bankwireDetails nofilter}</dd>
+      <dt>{l s='Bank name' d='Modules.Wirepayment.Shop'}</dt>
+      <dd>{$bankwireAddress nofilter}</dd>
+    </dl>
+    
     <p>
       {l s='Please specify your order reference %s in the bankwire description.' sprintf=[$reference] d='Modules.Wirepayment.Shop'}<br/>
-      {l s='We\'ve also sent you this information by e-mail.' d='Modules.Wirepayment.Shop'}
+      {l s='We\'ve also sent you this information by e-mail.' d='Modules.Wirepayment.Shop'}<br/>
+      {l s='Your order will be sent as soon as we receive payment.' d='Modules.Wirepayment.Shop'}
     </p>
-    <strong>{l s='Your order will be sent as soon as we receive payment.' d='Modules.Wirepayment.Shop'}</strong>
-    <p>
-      {l s='If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].' d='Modules.Wirepayment.Shop' sprintf=['[1]' => "<a href='{$contact_url}'>", '[/1]' => '</a>']}
+
+    <p class="mb-0">
+      {l s='If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].' 
+      d='Modules.Wirepayment.Shop' sprintf=['[1]' => "<a href='{$contact_url}'>", '[/1]' => '</a>']}
     </p>
-{else}
-    <p class="warning">
+  {else}
+    <p class="warning mb-0">
       {l s='We noticed a problem with your order. If you think this is an error, feel free to contact our [1]expert customer support team[/1].' d='Modules.Wirepayment.Shop' sprintf=['[1]' => "<a href='{$contact_url}'>", '[/1]' => '</a>']}
     </p>
-{/if}
+  {/if}
+</div>

--- a/modules/ps_wirepayment/views/templates/index.php
+++ b/modules/ps_wirepayment/views/templates/index.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * 2007-2020 PrestaShop and Contributors
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: post-check=0, pre-check=0', false);
+header('Pragma: no-cache');
+
+header('Location: ../../../../');
+exit;

--- a/src/scss/custom/components/_order-confirmation.scss
+++ b/src/scss/custom/components/_order-confirmation.scss
@@ -1,121 +1,76 @@
 $component-name: order-confirmation;
 
 .#{$component-name} {
-  &-title {
+  &__title {
     display: flex;
     align-items: center;
-    margin-bottom: 1rem;
-    font-weight: 500;
+    margin-bottom: 1.5rem;
+    font-weight: 700;
+    font-size: 1.5rem;
 
     i {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 2.5rem;
-      height: 2.5rem;
+      width: 2rem;
+      height: 2rem;
       margin-right: 1rem;
-      font-size: 2rem;
+      font-size: 1.5rem;
       color: $white;
-      background-color: $success;
+      background-color: #21834D;
       border-radius: 100%;
     }
   }
 
-  &-email {
-    margin-top: 0.25rem;
+  &__subtext {
     margin-bottom: 2rem;
     font-size: 1rem;
     color: $gray-800;
   }
 
-  &-details {
-    li {
-      margin-bottom: 0.25rem;
-    }
+  &__details {
+    .order-details {
+      margin-bottom: 0;
 
-    &-list {
-      p {
-        font-size: 1rem;
-        color: $gray-800;
-      }
-
-      ul {
-        margin: 1rem 0;
-        background: $gray-100;
-
-        li {
-          display: flex;
-          flex-wrap: wrap;
-          align-items: center;
-          padding: 0.5rem 1rem;
-        }
+      li {
+        margin-bottom: 0.25rem;
       }
     }
   }
 
-  &-items {
-    padding-bottom: 1rem;
-    margin-bottom: 2rem;
-    background: $gray-100;
+  &__totals > .row:not(:last-child),
+  &__subtotals > .row:not(:last-child) {
+    margin-bottom: 1rem;
   }
 
-  &-item {
-    padding: 1rem;
+  &__items > .row:not(:last-child) {
+    margin-bottom: 1rem;
+  }
 
-    &-prices {
+  &__items .item {
+    .item__prices {
       div {
         font-weight: 500;
         color: $gray-800;
       }
     }
 
-    &-title {
+    .item__reference {
+      margin-bottom: 0;
+    }
+
+    .item__title {
       font-weight: 600;
       color: $gray-800;
+      margin-bottom: 0;
     }
-  }
 
-  &-prices {
-    width: 100%;
-
-    .total-value {
-      border-top: 1px solid $gray-200;
-
-      td {
-        padding-top: 1.5rem;
+    .item__image {
+      text-align: center;
+  
+      img {
+        border-radius: 8px;
       }
-    }
-
-    tr:first-of-type {
-      border-top: 1px solid $gray-200;
-
-      td {
-        padding-top: 1.5rem;
-      }
-    }
-
-    td {
-      padding: 0.5rem 1rem;
-
-      &:last-of-type {
-        font-weight: 500;
-        color: $gray-800;
-        text-align: right;
-      }
-    }
-  }
-
-  &-subtotal {
-    td {
-      padding-bottom: 1rem;
-    }
-  }
-
-  &-image {
-    text-align: center;
-
-    img {
-      max-width: 5.5rem;
     }
   }
 }

--- a/templates/checkout/_partials/order-confirmation-table.tpl
+++ b/templates/checkout/_partials/order-confirmation-table.tpl
@@ -24,105 +24,114 @@
  *}
  {$componentName = 'order-confirmation'}
 
-<div id="order-items" class="{$componentName}-items">
-  <div class="order-confirmation-table">
-    {block name='order_confirmation_table'}
-      {foreach from=$products item=product}
-        <div class="order-confirmation-item row">
-          <div class="{$componentName}-image col-sm-1 col-xs-2">
-            <span class="image">
-              {if !empty($product.default_image)}
-                <img src="{$product.default_image.medium.url}" loading="lazy" />
-              {else}
-                <img src="{$urls.no_picture_image.bySize.medium_default.url}" loading="lazy" />
-              {/if}
-            </span>
-          </div>
-          <div class="{$componentName}-item-details col-sm-5 col-xs-10">
-            {if $add_product_link}<a href="{$product.url}" target="_blank">{/if}
-              <span class="{$componentName}-item-title">{$product.name}</span>
-            {if $add_product_link}</a>{/if}
-            {if is_array($product.customizations) && $product.customizations|count}
-              {foreach from=$product.customizations item="customization"}
-                <div class="customizations">
-                  <a href="#" data-bs-toggle="modal" data-target="#product-customizations-modal-{$customization.id_customization}">{l s='Product customization' d='Shop.Theme.Catalog'}</a>
-                </div>
-                <div class="modal fade customization-modal" id="product-customizations-modal-{$customization.id_customization}" tabindex="-1" role="dialog" aria-hidden="true">
-                  <div class="modal-dialog" role="document">
-                    <div class="modal-content">
-                      <div class="modal-header">
-                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{l s='Close' d='Shop.Theme.Global'}"></button>
-                        <h4 class="modal-title">{l s='Product customization' d='Shop.Theme.Catalog'}</h4>
+<div class="{$componentName}__table">
+
+  <div class="{$componentName}__items">
+  {foreach from=$products item=product}
+    <div class="item row gx-3">
+
+      <div class="item__image col-lg-1 col-md-2 col-sm-2 col-3 mb-2 mb-md-0">
+          {if !empty($product.default_image)}
+            <img src="{$product.default_image.medium.url}" loading="lazy" class="img-fluid" />
+          {else}
+            <img src="{$urls.no_picture_image.bySize.medium_default.url}" loading="lazy" class="img-fluid" />
+          {/if}
+      </div>
+
+      <div class="item__details col-lg-9 col-md-8 col-sm-10 col-7">
+        {if $add_product_link}<a href="{$product.url}" target="_blank">{/if}
+          <p class="item__title">{$product.name}</p>
+        {if $add_product_link}</a>{/if}
+
+        {if !empty($product.reference)}
+          <p class="item__reference">{l s='Reference' d='Shop.Theme.Catalog'} {$product.reference}</p>
+        {/if}
+
+        {if is_array($product.customizations) && $product.customizations|count}
+          {foreach from=$product.customizations item="customization"}
+            <div class="customizations">
+              <a href="#" data-bs-toggle="modal" data-target="#product-customizations-modal-{$customization.id_customization}">{l s='Product customization' d='Shop.Theme.Catalog'}</a>
+            </div>
+            <div class="modal fade customization-modal" id="product-customizations-modal-{$customization.id_customization}" tabindex="-1" role="dialog" aria-hidden="true">
+              <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{l s='Close' d='Shop.Theme.Global'}"></button>
+                    <h4 class="modal-title">{l s='Product customization' d='Shop.Theme.Catalog'}</h4>
+                  </div>
+                  <div class="modal-body">
+                    {foreach from=$customization.fields item="field"}
+                      <div class="product-customization-line row">
+                        <div class="col-sm-3 col-4 label">
+                          {$field.label}
+                        </div>
+                        <div class="col-sm-9 col-8 value">
+                          {if $field.type == 'text'}
+                            {if (int)$field.id_module}
+                              {$field.text nofilter}
+                            {else}
+                              {$field.text}
+                            {/if}
+                          {elseif $field.type == 'image'}
+                            <img src="{$field.image.small.url}" loading="lazy">
+                          {/if}
+                        </div>
                       </div>
-                      <div class="modal-body">
-                        {foreach from=$customization.fields item="field"}
-                          <div class="product-customization-line row">
-                            <div class="col-sm-3 col-xs-4 label">
-                              {$field.label}
-                            </div>
-                            <div class="col-sm-9 col-xs-8 value">
-                              {if $field.type == 'text'}
-                                {if (int)$field.id_module}
-                                  {$field.text nofilter}
-                                {else}
-                                  {$field.text}
-                                {/if}
-                              {elseif $field.type == 'image'}
-                                <img src="{$field.image.small.url}" loading="lazy">
-                              {/if}
-                            </div>
-                          </div>
-                        {/foreach}
-                      </div>
-                    </div>
+                    {/foreach}
                   </div>
                 </div>
-              {/foreach}
-            {/if}
-            {hook h='displayProductPriceBlock' product=$product type="unit_price"}
-          </div>
-          <div class="{$componentName}-item-prices col-sm-6 qty">
-            <div class="row">
-              <div class="col-xs-4 text-end">{$product.price}</div>
-              <div class="col-xs-4 text-end">{$product.quantity}</div>
-              <div class="col-xs-4 text-end">{$product.total}</div>
+              </div>
             </div>
-          </div>
+          {/foreach}
+        {/if}
+        
+        {hook h='displayProductPriceBlock' product=$product type="unit_price"}
+      </div>
+      
+      <div class="item__prices col-md-2 col-sm-12 col-12">
+        <div class="text-md-end">{$product.price}</div>
+        <div class="text-md-end">{$product.quantity}</div>
+        <div class="text-md-end">{$product.total}</div>
+      </div>
+
+    </div>
+  {/foreach}
+  </div>
+  <hr>
+
+  <div class="{$componentName}__subtotals">
+    {foreach $subtotals as $subtotal}
+      {if $subtotal !== null && $subtotal.type !== 'tax' && $subtotal.label !== null}
+        <div class="row">
+          <div class="col-6">{$subtotal.label}</div>
+          <div class="col-6 text-end">{if 'discount' == $subtotal.type}-&nbsp;{/if}{$subtotal.value}</div>
         </div>
-      {/foreach}
+      {/if}
+    {/foreach}
+  </div>
+  <hr>
 
-      <table class="{$componentName}-prices">
-        {foreach $subtotals as $subtotal}
-          {if $subtotal !== null && $subtotal.type !== 'tax' && $subtotal.label !== null}
-            <tr class="{$componentName}-subtotal">
-              <td>{$subtotal.label}</td>
-              <td>{if 'discount' == $subtotal.type}-&nbsp;{/if}{$subtotal.value}</td>
-            </tr>
-          {/if}
-        {/foreach}
-
-        {if !$configuration.display_prices_tax_incl && $configuration.taxes_enabled}
-          <tr>
-            <td><span class="text-uppercase">{$totals.total.label}&nbsp;{$labels.tax_short}</span></td>
-            <td>{$totals.total.value}</td>
-          </tr>
-          <tr class="total-value fw-bold">
-            <td><span class="text-uppercase">{$totals.total_including_tax.label}</span></td>
-            <td>{$totals.total_including_tax.value}</td>
-          </tr>
-        {else}
-          <tr class="total-value fw-bold">
-            <td><span class="text-uppercase">{$totals.total.label}&nbsp;{if $configuration.taxes_enabled}{$labels.tax_short}{/if}</span></td>
-            <td>{$totals.total.value}</td>
-          </tr>
-        {/if}
-        {if $subtotals.tax !== null && $subtotals.tax.label !== null}
-          <tr class="sub taxes">
-            <td colspan="2"><span class="label">{l s='%label%:' sprintf=['%label%' => $subtotals.tax.label] d='Shop.Theme.Global'}</span>&nbsp;<span class="value">{$subtotals.tax.value}</span></td>
-          </tr>
-        {/if}
-      </table>
-    {/block}
-
+  <div class="{$componentName}__totals">
+    {if !$configuration.display_prices_tax_incl && $configuration.taxes_enabled}
+      <div class="row">
+        <div class="col-6">{$totals.total.label}&nbsp;{$labels.tax_short}</div>
+        <div class="col-6 text-end">{$totals.total.value}</td>
+      </div>
+      <div class="row fw-bold">
+        <div class="col-6">{$totals.total_including_tax.label}</div>
+        <div class="col-6 text-end">{$totals.total_including_tax.value}</td>
+      </div>
+    {else}
+      <div class="row fw-bold">
+        <div class="col-6">{$totals.total.label}&nbsp;{if $configuration.taxes_enabled}{$labels.tax_short}{/if}</div>
+        <div class="col-6 text-end">{$totals.total.value}</div>
+      </div>
+    {/if}
+    {if $subtotals.tax !== null && $subtotals.tax.label !== null}
+      <div class="row">
+        <div class="col-6">{l s='%label%:' sprintf=['%label%' => $subtotals.tax.label] d='Shop.Theme.Global'}</div>
+        <div class="col-6 text-end">{$subtotals.tax.value}</div>
+      </div>
+    {/if}
   </div>
 </div>

--- a/templates/checkout/order-confirmation.tpl
+++ b/templates/checkout/order-confirmation.tpl
@@ -13,12 +13,12 @@
         {if $order.details.invoice_url}
           {* [1][/1] is for a HTML tag. *}
           {l
-                  s='You can also [1]download your invoice[/1].'
-                  d='Shop.Theme.Checkout'
-                  sprintf=[
-                    '[1]' => "<a href='{$order.details.invoice_url}'>",
-          '[/1]' => "</a>"
-          ]
+            s='You can also [1]download your invoice[/1].'
+            d='Shop.Theme.Checkout'
+            sprintf=[
+              '[1]' => "<a href='{$order.details.invoice_url}'>",
+              '[/1]' => "</a>"
+            ]
           }
         {/if}
       </p>

--- a/templates/checkout/order-confirmation.tpl
+++ b/templates/checkout/order-confirmation.tpl
@@ -1,88 +1,78 @@
-{extends file='page.tpl'}
+{extends file=$layout}
 {$componentName = 'order-confirmation'}
 
-{block name='page_content_container' prepend}
-    <section id="{$componentName}-header">
-      {block name='order_confirmation_header'}
-        <h3 class="h2 {$componentName}-title">
-          <i class="material-icons rtl-no-flip done">&#xE876;</i>{l s='Your order is confirmed' d='Shop.Theme.Checkout'}
-        </h3>
-      {/block}
+{block name='content'}
 
-      <p class="{$componentName}-email">
-        {l s='An email has been sent to your mail address %email%.' d='Shop.Theme.Checkout' sprintf=['%email%' => $customer.email]}
+  {block name='order_confirmation_header'}
+    <div class="{$componentName}__header">
+      <h1 class="{$componentName}__title">
+        <i class="material-icons rtl-no-flip done">&#xE876;</i>{l s='Your order is confirmed' d='Shop.Theme.Checkout'}
+      </h1>
+      <p class="{$componentName}__subtext">
+        {l s='An email has been sent to your mail address %email%.' d='Shop.Theme.Checkout' sprintf=['%email%' => $order_customer.email]}
         {if $order.details.invoice_url}
           {* [1][/1] is for a HTML tag. *}
           {l
-            s='You can also [1]download your invoice[/1]'
-            d='Shop.Theme.Checkout'
-            sprintf=[
-              '[1]' => "<a href='{$order.details.invoice_url}'>",
-              '[/1]' => "</a>"
-            ]
+                  s='You can also [1]download your invoice[/1].'
+                  d='Shop.Theme.Checkout'
+                  sprintf=[
+                    '[1]' => "<a href='{$order.details.invoice_url}'>",
+          '[/1]' => "</a>"
+          ]
           }
         {/if}
       </p>
-
-      {block name='hook_order_confirmation'}
-        {$HOOK_ORDER_CONFIRMATION nofilter}
-      {/block}
-    </section>
-{/block}
-
-{block name='page_content_container'}
-  <section id="content" class="page-content page-order-confirmation {$componentName}">
-    {block name='order_details'}
-      <div id="{$componentName}-details" class="{$componentName}-details col-md-4">
-        <ul>
-          <li id="order-reference-value">{l s='Order reference: %reference%' d='Shop.Theme.Checkout' sprintf=['%reference%' => $order.details.reference]}</li>
-          <li>{l s='Payment method: %method%' d='Shop.Theme.Checkout' sprintf=['%method%' => $order.details.payment]}</li>
-          {if !$order.details.is_virtual}
-            <li>
-              {l s='Shipping method: %method%' d='Shop.Theme.Checkout' sprintf=['%method%' => $order.carrier.name]} - 
-              <span>{$order.carrier.delay}</span>
-            </li>
-          {/if}
-        </ul>
-      </div>
-    {/block}
-
-    {block name='order_confirmation_table'}
-      {include
-        file='checkout/_partials/order-confirmation-table.tpl'
-        products=$order.products
-        subtotals=$order.subtotals
-        totals=$order.totals
-        labels=$order.labels
-        add_product_link=false
-      }
-    {/block}
-  </section>
+    </div>
+  {/block}
 
   {block name='hook_payment_return'}
     {if !empty($HOOK_PAYMENT_RETURN)}
-    <section id="content-hook_payment_return" class="{$componentName}-details-list">
       {$HOOK_PAYMENT_RETURN nofilter}
-    </section>
     {/if}
   {/block}
 
-  {block name='customer_registration_form'}
-    {if $customer.is_guest}
-      <div id="registration-form">
-        <h4 class="h4">{l s='Save time on your next order, sign up now' d='Shop.Theme.Checkout'}</h4>
-          {render file='customer/_partials/customer-form.tpl' ui=$register_form}
-      </div>
-    {/if}
+  {block name='hook_order_confirmation'}
+    {$HOOK_ORDER_CONFIRMATION nofilter}
   {/block}
+
+  {block name='order_details'}    
+    <div class="{$componentName}__details card card-body mb-3 bg-light">
+      <h2 class="h4">{l s='Order details' d='Shop.Theme.Checkout'}</h2>
+      <ul class="order-details">
+        <li>{l s='Order reference: %reference%' d='Shop.Theme.Checkout' sprintf=['%reference%' => $order.details.reference]}</li>
+        <li>{l s='Payment method: %method%' d='Shop.Theme.Checkout' sprintf=['%method%' => $order.details.payment]}</li>
+        {if !$order.details.is_virtual}
+          <li>{l s='Shipping method: %method%' d='Shop.Theme.Checkout' sprintf=['%method%' => $order.carrier.name]} - {$order.carrier.delay}</li>
+        {/if}
+      </ul>
+      <hr>
+      {block name='order_confirmation_table'}
+        {include
+                file='checkout/_partials/order-confirmation-table.tpl'
+                products=$order.products
+                subtotals=$order.subtotals
+                totals=$order.totals
+                labels=$order.labels
+                add_product_link=false
+              }
+      {/block}
+    </div>
+  {/block}
+
+  {if !$registered_customer_exists}
+    {block name='account_transformation_form'}
+      <div class="card card-body bg-light mb-3 {$componentName}__account-transformation">
+        {include file='customer/_partials/account-transformation-form.tpl'}
+      </div>
+    {/block}
+  {/if}
 
   {block name='hook_order_confirmation_1'}
     {hook h='displayOrderConfirmation1'}
   {/block}
 
   {block name='hook_order_confirmation_2'}
-    <section id="content-hook-order-confirmation-footer">
-      {hook h='displayOrderConfirmation2'}
-    </section>
+    {hook h='displayOrderConfirmation2'}
   {/block}
+
 {/block}

--- a/templates/customer/_partials/account-transformation-form.tpl
+++ b/templates/customer/_partials/account-transformation-form.tpl
@@ -22,22 +22,21 @@
  * @copyright Since 2007 PrestaShop SA and Contributors
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
-{extends file='customer/order-detail.tpl'}
-
-{block name='page_title'}
-  {l s='Guest Tracking' d='Shop.Theme.Customeraccount'}
+ {block name='account_transformation_form'}
+  <h4>{l s='Save time on your next order, sign up now' d='Shop.Theme.Checkout'}</h4>
+  <ul>
+    <li> - {l s='Personalized and secure access' d='Shop.Theme.Customeraccount'}</li>
+    <li> - {l s='Fast and easy checkout' d='Shop.Theme.Customeraccount'}</li>
+    <li> - {l s='Easier merchandise return' d='Shop.Theme.Customeraccount'}</li>
+  </ul>
+  <form method="post">
+    <div class="mb-3">
+      <label class="form-label" for="field-email">
+        {l s='Set your password:' d='Shop.Forms.Labels'}
+      </label>
+      <input type="password" class="form-control" data-validate="isPasswd" required name="password" value="">
+    </div>
+    <input type="hidden" name="submitTransformGuestToCustomer" value="1">
+    <button class="btn btn-primary" type="submit">{l s='Create account' d='Shop.Theme.Actions'}</button>
+  </form>
 {/block}
-
-{block name='order_detail'}
-  {include file='customer/_partials/order-detail-no-return.tpl'}
-{/block}
-
-{block name='order_messages'}
-{/block}
-
-{if !$registered_customer_exists}
-  {block name='page_content' append}
-    {block name='account_transformation_form'}
-    {include file='customer/_partials/account-transformation-form.tpl'}
-  {/block}
-{/if}

--- a/templates/customer/guest-tracking.tpl
+++ b/templates/customer/guest-tracking.tpl
@@ -38,6 +38,7 @@
 {if !$registered_customer_exists}
   {block name='page_content' append}
     {block name='account_transformation_form'}
-    {include file='customer/_partials/account-transformation-form.tpl'}
+      {include file='customer/_partials/account-transformation-form.tpl'}
+    {/block}
   {/block}
 {/if}


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Styling of confirmation page and default module messages.
| Type?             | refacto
| BC breaks?        | -
| Deprecations?     | -
| Fixed ticket?     | -
| How to test?      | -
| Possible impacts? | -

### Details
- Not fully finished, but refacto and bringing closer to spec.
- Refacto confirmation page.
- Backport guest conversion fix from classic.
- Styled all default module return messages.
- Moved the hooks to proper position for payment returns to be visible.

![localhost_prestashop_order-confirmation_id_cart=12 id_module=42 id_order=7 key=b2d0b38d27e507e2c930f18ec3c03c9d](https://user-images.githubusercontent.com/6097524/153273849-3fd2ab4c-e494-4ada-8036-02cfcea261e1.png)
